### PR TITLE
Increase the limit of open files to 2^20

### DIFF
--- a/templates/kafka.service.erb
+++ b/templates/kafka.service.erb
@@ -19,7 +19,7 @@ EnvironmentFile=/etc/default/kafka
 User=kafka
 Group=kafka
 ExecStart=/bin/sh -c /etc/kafka/start.sh
-LimitNOFILE=65535
+LimitNOFILE=1048576
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This is the limit on most hosts nowadays and should prevent issues when
Kafka needs file when hosting a lot of partitions.

    $ sysctl fs.nr_open
    fs.nr_open = 1048576